### PR TITLE
error when attribute defined but a method with that name already exists

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,18 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task :spec => :test
+namespace :test do
+  task :watch do |t, args|
+    require "filewatcher"
+
+    watcher = Filewatcher.new(["spec/", "lib/"], :every => true, :spinner => true, :immediate => true)
+    watcher.watch do |filename, event|
+      begin
+        Rake::Task[:test].execute(args)
+      rescue StandardError => error
+        puts "Error: #{error.message}"
+      end
+    end
+  end
+end
 task :default => :test

--- a/gourami.gemspec
+++ b/gourami.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "pry", "~>0.10"
   spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "filewatcher", "~> 1.1.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "pry", "~>0.10"
+  spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/gourami.rb
+++ b/lib/gourami.rb
@@ -2,6 +2,7 @@ module Gourami
 end
 
 require "gourami/error"
+require "gourami/attribute_name_conflict_error"
 require "gourami/configuration_error"
 require "gourami/not_watching_changes_error"
 require "gourami/required_attribute_error"

--- a/lib/gourami/attribute_name_conflict_error.rb
+++ b/lib/gourami/attribute_name_conflict_error.rb
@@ -1,0 +1,4 @@
+module Gourami
+  class AttributeNameConflictError < Gourami::Error
+  end
+end

--- a/lib/gourami/attributes.rb
+++ b/lib/gourami/attributes.rb
@@ -20,11 +20,16 @@ module Gourami
       # @block default_block
       #   If provided, the block will be applied to options as the :default
       def attribute(name, options = {}, &default_block)
+        base = self
         options = options.dup
         options[:default] = default_block if block_given?
 
         mixin = Module.new do |mixin|
           unless options[:skip_reader]
+            if base.instance_methods.include?(name) && !options[:override_reader]
+              raise AttributeNameConflictError, "#{name} is already a method. To use the existing method, use `:skip_reader => true` option. To override the existing method, use `:override_reader => true` option."
+            end
+
             mixin.send(:define_method, :"#{name}") do
               value = instance_variable_get(:"@#{name}")
               default = options[:default]

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -2,7 +2,9 @@ require_relative "./spec_helper"
 
 describe Gourami::Attributes do
   let(:form_class) do
-    Class.new.tap { |c| c.send(:include, Gourami::Attributes) }
+    Class.new do |klass|
+      klass.include(Gourami::Attributes)
+    end
   end
 
   describe "#provided_attributes" do
@@ -41,6 +43,44 @@ describe Gourami::Attributes do
 
       form.provide_me_too = nil
       assert_equal({ :provide_me => nil, :provide_me_too => nil }, form.provided_attributes)
+    end
+  end
+
+  describe ".attribute" do
+    describe "when a method with the attribute name already exists" do
+      let(:form_class) do
+        Class.new do |klass|
+          klass.include(Module.new do
+            # Have to `include` a mixin to define the existing method because of weird Ruby quirk with class block syntax and method inheritance chain https://www.ruby-forum.com/t/module-to-overwrite-method-defined-via-define-method/175422/3
+            def existing_method_name
+              "original method return value"
+            end
+          end)
+          klass.include(Gourami::Attributes)
+        end
+      end
+
+      it "raises an exception by default" do
+        assert_raises Gourami::AttributeNameConflictError do
+          form_class.attribute(:existing_method_name)
+        end
+      end
+
+      it "supports opt-out with :skip_reader => true option" do
+        form_class.attribute(:existing_method_name, :skip_reader => true)
+        form = form_class.new(:existing_method_name => "attribute value")
+        assert_equal("attribute value", form.instance_variable_get(:@existing_method_name))
+        assert_equal("original method return value", form.attributes[:existing_method_name])
+        assert_equal("original method return value", form.existing_method_name)
+      end
+
+      it "supports opt-in with explicit :override_reader => true option" do
+        form_class.attribute(:existing_method_name, :override_reader => true)
+        form = form_class.new(:existing_method_name => "attribute value")
+        assert_equal("attribute value", form.instance_variable_get(:@existing_method_name))
+        assert_equal("attribute value", form.attributes[:existing_method_name])
+        assert_equal("attribute value", form.existing_method_name)
+      end
     end
   end
 end


### PR DESCRIPTION
 - raise AttributeNameConflictError when attribute defined but a method with that name already exists
 - introduce :override_reader attribute option
 - spec :skip_reader
 - Introduce `rake test:watch` task using Filewatcher gem
