### PR TITLE
skip_reader not required when overriding gourami attributes

### DIFF
--- a/lib/gourami/attributes.rb
+++ b/lib/gourami/attributes.rb
@@ -2,6 +2,7 @@ module Gourami
   module Attributes
 
     module ClassMethods
+
       # Copy parent attributes to inheriting class.
       #
       # @param klass [Class]
@@ -26,7 +27,7 @@ module Gourami
 
         mixin = Module.new do |mixin|
           unless options[:skip_reader]
-            if base.instance_methods.include?(name) && !options[:override_reader]
+            if !base.attributes.key?(name) && base.instance_methods.include?(name) && !options[:override_reader]
               raise AttributeNameConflictError, "#{name} is already a method. To use the existing method, use `:skip_reader => true` option. To override the existing method, use `:override_reader => true` option."
             end
 

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -50,13 +50,13 @@ describe Gourami::Attributes do
     describe "when a method with the attribute name already exists" do
       let(:form_class) do
         Class.new do |klass|
+          klass.include(Gourami::Attributes)
           klass.include(Module.new do
             # Have to `include` a mixin to define the existing method because of weird Ruby quirk with class block syntax and method inheritance chain https://www.ruby-forum.com/t/module-to-overwrite-method-defined-via-define-method/175422/3
             def existing_method_name
               "original method return value"
             end
           end)
-          klass.include(Gourami::Attributes)
         end
       end
 
@@ -80,6 +80,57 @@ describe Gourami::Attributes do
         assert_equal("attribute value", form.instance_variable_get(:@existing_method_name))
         assert_equal("attribute value", form.attributes[:existing_method_name])
         assert_equal("attribute value", form.existing_method_name)
+      end
+
+      describe "when the method is defined from a Gourami attribute" do
+
+        let(:form_class) do
+          Class.new do |klass|
+            klass.include(Gourami::Attributes)
+            klass.include(Module.new do |mod|
+              def self.included(base)
+                super
+                base.attribute(:existing_attribute_name, :default => "original attribute default value")
+                base.attribute(:existing_skip_attribute_name, :default => "skip option has no impact", :skip => true)
+                base.attribute(:other_attribute_name, :default => "other attribute remains in class.attributes")
+              end
+            end)
+          end
+        end
+
+        it "overrides the previously defined attribute without problem" do
+          # Before attribute redefine uses previous attribute options
+          form = form_class.new
+          assert_equal("original attribute default value", form.existing_attribute_name)
+          assert_equal("skip option has no impact", form.existing_skip_attribute_name)
+          assert_equal("other attribute remains in class.attributes", form.other_attribute_name)
+
+          assert_equal({
+            :existing_attribute_name => { :default => "original attribute default value" },
+            :existing_skip_attribute_name => { :default => "skip option has no impact", :skip => true },
+            :other_attribute_name => { :default => "other attribute remains in class.attributes" },
+          }, form_class.attributes)
+
+          # Redefine attributes without problem
+          form_class.attribute(:existing_attribute_name, :default => "new default")
+          form_class.attribute(:existing_skip_attribute_name)
+          form_class.attribute(:new_attribute_name, :skip => true)
+
+          assert_equal({
+            :existing_attribute_name => { :default => "new default" },
+            :existing_skip_attribute_name => {},
+            :other_attribute_name => { :default => "other attribute remains in class.attributes" },
+            :new_attribute_name => { :skip => true },
+          }, form_class.attributes)
+
+          # After attribute redefine uses new attribute options
+          form = form_class.new
+          assert_equal("new default", form.existing_attribute_name)
+          assert_nil(form.existing_skip_attribute_name)
+          assert_equal("other attribute remains in class.attributes", form.other_attribute_name)
+          assert_nil(form.new_attribute_name)
+        end
+
       end
     end
   end


### PR DESCRIPTION
Now only required when overriding non-attribute methods.