### PR TITLE
2.0.0 Introduce with_each_resource and validate_decimal_places

### DIFF
--- a/lib/gourami/extensions/resources.rb
+++ b/lib/gourami/extensions/resources.rb
@@ -16,12 +16,31 @@ module Gourami
       #       validate_presence(:title) # validates `attributes[:social_broadcasts][<EACH>][:title]`
       #     end
       #   end
+      #
+      # @example
+      #   def validate
+      #     with_each_resource(:items, offset: existing_items.count) do |item, key, index|
+      #       # Standard validation methods are available, and will validate the attributes on the resource:
+      #       validate_decimal_places(:price, max: 2)
+      #
+      #       # You may reference the resource object directly to perform custom validation logic inline:
+      #       append_error(:password_confirmation, :doesnt_match) if item["password"] != item["password_confirmation"]
+      #
+      #       # If `items` is a Hash, `key` is the hash key of the resource.
+      #       # If `items` is an Array, `key` is the index of the resource (`+ offset`, if an offset is given).
+      #       validate_length(:name, max: 255) if key % 2 == 0
+      #
+      #       # If `items` is a Hash, `index` is the hash key of the resource.
+      #       # If `items` is an Array, `index` is the index of the resource (offset is NOT applied to index).
+      #       append_error(:id, :is_invalid) if index > 500
+      #     end
+      #   end
       def with_each_resource(resource_namespace, offset: nil, &_block)
         resources = send(resource_namespace)
         if resources.is_a?(Hash)
-          return resources.each_with_index do |(resource_uid, resource), index|
-            with_resource(resource_namespace, resource_uid, offset: offset) do
-              yield(resource, resource_uid, index)
+          return resources.each_with_index do |(key, resource), index|
+            with_resource(resource_namespace, key, offset: offset) do
+              yield(resource, key, index)
             end
           end
         end

--- a/lib/gourami/extensions/resources.rb
+++ b/lib/gourami/extensions/resources.rb
@@ -2,11 +2,34 @@ module Gourami
   module Extensions
     module Resources
 
+      # yield to the given block for each resource in the given namespace.
+      #
+      # @param resource_namespace [Symbol] The namespace of the resource (e.g. :users, :payments)
+      #
+      # @option offset [Integer] The offset of the resource (e.g. 0, 1, 2) for example in an update form, there may be existing items that already exist, however only the new items are sent to the form.
+      #
+      # @yield The block to execute, each time with a resource active.
+      #
+      # @example
+      #   def validate
+      #     with_each_resource(:social_broadcasts) do
+      #       validate_presence(:title) # validates `attributes[:social_broadcasts][<EACH>][:title]`
+      #     end
+      #   end
+      def with_each_resource(resource_namespace, offset: 0, &_block)
+        send(resource_namespace).each_with_index do |resource, resource_uid|
+          with_resource(resource_namespace, resource_uid, offset: offset) do
+            yield(resource, resource_uid)
+          end
+        end
+      end
+
       # For the duration of the given block, all validations will be done on the given resource.
       #
       # @param resource_namespace [Symbol] The namespace of the resource (e.g. :users, :payments)
       # @param resource_uid [String|Number] The uid of the resource (e.g. 0, 1, "123")
-      # @param offset [Integer] The offset of the resource (e.g. 0, 1, 2) for example in an update form, there may be existing items that already exist, however only the new items are sent to the form.
+      #
+      # @option offset [Integer] The offset of the resource (e.g. 0, 1, 2) for example in an update form, there may be existing items that already exist, however only the new items are sent to the form.
       #
       # @yield The block to execute with the resource active.
       #

--- a/lib/gourami/extensions/resources.rb
+++ b/lib/gourami/extensions/resources.rb
@@ -44,7 +44,7 @@ module Gourami
 
       # If a resource namespace is active (within with_resource block), append the error to the resource.
       # Otherwise, append the error to the form object.
-      def append_maybe_resource_error(attribute_name, message)
+      def append_error(attribute_name, message)
         if @resource_namespace
           append_resource_error(@resource_namespace, @resource_uid + @offset, attribute_name, message)
         else

--- a/lib/gourami/extensions/resources.rb
+++ b/lib/gourami/extensions/resources.rb
@@ -26,9 +26,9 @@ module Gourami
           end
         end
 
-        send(resource_namespace).each_with_index do |resource, resource_uid|
-          with_resource(resource_namespace, resource_uid, offset: offset) do
-            yield(resource, resource_uid)
+        send(resource_namespace).each_with_index do |resource, index|
+          with_resource(resource_namespace, index, offset: offset) do
+            yield(resource, offset ? index + offset : index, index)
           end
         end
       end

--- a/lib/gourami/validations.rb
+++ b/lib/gourami/validations.rb
@@ -85,7 +85,7 @@ module Gourami
     # @param attribute_name [Symbol, nil] nil for base
     # @param error [Symbol, String]
     #   The error identifier.
-    def append_error(attribute_name, error)
+    def append_root_error(attribute_name, error)
       errors[attribute_name] << error
     end
 
@@ -98,8 +98,8 @@ module Gourami
     end
 
     # Overridden and super invoked from Extensions::Resources
-    def append_maybe_resource_error(attribute_name, message)
-      append_error(attribute_name, message)
+    def append_error(attribute_name, message)
+      append_root_error(attribute_name, message)
     end
 
     def get_current_resource_attribute_value(attribute_name)
@@ -125,7 +125,7 @@ module Gourami
     def validate_presence(attribute_name, message = nil)
       value = get_current_resource_attribute_value(attribute_name)
       if !value || value.to_s.strip.empty?
-        append_maybe_resource_error(attribute_name, message || :cant_be_empty)
+        append_error(attribute_name, message || :cant_be_empty)
       end
     end
 
@@ -140,7 +140,7 @@ module Gourami
     def validate_uniqueness(attribute_name, message = nil, &block)
       value = get_current_resource_attribute_value(attribute_name)
       unless block.call(value)
-        append_maybe_resource_error(attribute_name, message || :is_duplicated)
+        append_error(attribute_name, message || :is_duplicated)
       end
     end
 
@@ -168,7 +168,7 @@ module Gourami
     def validate_format(attribute_name, format, message = nil)
       value = get_current_resource_attribute_value(attribute_name)
       if value && !(format =~ value)
-        append_maybe_resource_error(attribute_name, message || :is_invalid)
+        append_error(attribute_name, message || :is_invalid)
       end
     end
 
@@ -196,11 +196,11 @@ module Gourami
 
         if min && length < min
           did_append_error = true
-          append_maybe_resource_error(attribute_name, options.fetch(:min_message, nil) || :is_too_short)
+          append_error(attribute_name, options.fetch(:min_message, nil) || :is_too_short)
         end
         if max && length > max
           did_append_error = true
-          append_maybe_resource_error(attribute_name, options.fetch(:max_message, nil) || :is_too_long)
+          append_error(attribute_name, options.fetch(:max_message, nil) || :is_too_long)
         end
 
         errors[attribute_name] if did_append_error
@@ -216,7 +216,7 @@ module Gourami
     def validate_inclusion(attribute_name, list, message = nil)
       value = get_current_resource_attribute_value(attribute_name)
       if value && !list.include?(value)
-        append_maybe_resource_error(attribute_name, message || :isnt_listed)
+        append_error(attribute_name, message || :isnt_listed)
       end
     end
 
@@ -226,7 +226,7 @@ module Gourami
       value = get_current_resource_attribute_value(attribute_name)
       value && value.each do |obj|
         unless list.include?(obj)
-          append_maybe_resource_error(attribute_name, message || "#{obj} isn't listed")
+          append_error(attribute_name, message || "#{obj} isn't listed")
           break
         end
       end
@@ -239,7 +239,7 @@ module Gourami
     def validate_any(attribute_name, message = nil)
       value = get_current_resource_attribute_value(attribute_name)
       if value && value.empty?
-        append_maybe_resource_error(attribute_name, message || :cant_be_empty)
+        append_error(attribute_name, message || :cant_be_empty)
       end
     end
 
@@ -251,7 +251,7 @@ module Gourami
     def validate_filetype(attribute_name, filetypes, message = nil)
       value = get_current_resource_attribute_value(attribute_name)
       if value && !filetypes.include?(value[:type].to_s.split("/").first)
-        append_maybe_resource_error(attribute_name, message || :is_invalid)
+        append_error(attribute_name, message || :is_invalid)
       end
     end
 
@@ -272,8 +272,8 @@ module Gourami
 
       min = options.fetch(:min, nil)
       max = options.fetch(:max, nil)
-      append_maybe_resource_error(attribute_name, options.fetch(:min_message, nil) || :less_than_min) if min && value < min
-      append_maybe_resource_error(attribute_name, options.fetch(:max_message, nil) || :greater_than_max) if max && value > max
+      append_error(attribute_name, options.fetch(:min_message, nil) || :less_than_min) if min && value < min
+      append_error(attribute_name, options.fetch(:max_message, nil) || :greater_than_max) if max && value > max
     end
 
     # Ensure the provided numeric attribute has the correct number of decimal places within the given range.
@@ -298,11 +298,11 @@ module Gourami
       decimal_places = value.split(".", 2).last&.length || 0
 
       if max && max > 0 && decimal_places > max
-        append_maybe_resource_error(attribute_name, max_message || :too_many_decimal_places)
+        append_error(attribute_name, max_message || :too_many_decimal_places)
       end
 
       if min && min > 0 && decimal_places < min
-        append_maybe_resource_error(attribute_name, min_message || :too_few_decimal_places)
+        append_error(attribute_name, min_message || :too_few_decimal_places)
       end
     end
 

--- a/lib/gourami/version.rb
+++ b/lib/gourami/version.rb
@@ -1,3 +1,3 @@
 module Gourami
-  VERSION = "1.4.0".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/spec/extensions/resources_spec.rb
+++ b/spec/extensions/resources_spec.rb
@@ -140,10 +140,53 @@ describe Gourami::Extensions::Resources do
         ],
       )
       offset = 3
-      form.with_each_resource(:items, offset: offset) do |item, index|
+
+      received_items = []
+      received_keys = []
+      received_indexes = []
+      form.with_each_resource(:items, offset: offset) do |item, key, index|
+        received_items << item
+        received_keys << key
+        received_indexes << index
+
         form.validate_presence(:name)
         form.append_error(:id, :is_invalid) if item["id"] > 500
       end
+
+      assert_equal(
+        [
+          {
+            "name" => "Sean",
+            "id" => 123,
+          },
+          {
+            "name" => "Leigh",
+            "id" => 456,
+          },
+          {
+            "name" => "",
+            "id" => 789,
+          },
+        ],
+        received_items
+      )
+      assert_equal(
+        [
+          offset + 0,
+          offset + 1,
+          offset + 2,
+        ],
+        received_keys
+      )
+
+      assert_equal(
+        [
+          0,
+          1,
+          2,
+        ],
+        received_indexes
+      )
 
       assert_equal(false, form.resource_has_errors?(:items, offset + 0))
       assert_equal(false, form.resource_has_errors?(:items, offset + 1))
@@ -216,10 +259,53 @@ describe Gourami::Extensions::Resources do
           },
         }
       )
-      form.with_each_resource(:items_hash) do |item, index|
+
+      received_items = []
+      received_keys = []
+      received_indexes = []
+      form.with_each_resource(:items_hash) do |item, key, index|
+        received_items << item
+        received_keys << key
+        received_indexes << index
+
         form.validate_presence(:name)
         form.append_error(:id, :is_invalid) if item["id"] > 500
       end
+
+      assert_equal(
+        [
+          {
+            "name" => "Sean",
+            "id" => 123,
+          },
+          {
+            "name" => "Leigh",
+            "id" => 456,
+          },
+          {
+            "name" => "",
+            "id" => 789,
+          },
+        ],
+        received_items
+      )
+      assert_equal(
+        [
+          "abc",
+          "def",
+          "ghi",
+        ],
+        received_keys
+      )
+
+      assert_equal(
+        [
+          0,
+          1,
+          2,
+        ],
+        received_indexes
+      )
 
       assert_equal(false, form.resource_has_errors?(:items_hash, "abc"))
       assert_equal(false, form.resource_has_errors?(:items_hash, "def"))

--- a/spec/extensions/resources_spec.rb
+++ b/spec/extensions/resources_spec.rb
@@ -55,7 +55,7 @@ describe Gourami::Extensions::Resources do
     end
   end
 
-  describe "#with_resource" do
+  describe "#with_resource(:items, index)" do
     it "validations within the block are scoped to the resource" do
       form = form_class.new(
         items: [
@@ -73,23 +73,61 @@ describe Gourami::Extensions::Resources do
           },
         ],
       )
+      offset = 3
       form.items.each_with_index do |item, index|
-        form.with_resource(:items, index) do
+        form.with_resource(:items, index, offset: offset) do
           form.validate_presence(:name)
           form.append_error(:id, :is_invalid) if item["id"] > 500
         end
       end
-      assert_equal(false, form.resource_has_errors?(:items, 0))
-      assert_equal(false, form.resource_has_errors?(:items, 1))
-      assert_equal(true, form.resource_has_errors?(:items, 2))
+      assert_equal(false, form.resource_has_errors?(:items, offset + 0))
+      assert_equal(false, form.resource_has_errors?(:items, offset + 1))
+      assert_equal(true, form.resource_has_errors?(:items, offset + 2))
 
-      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :name))
-      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :id))
-      assert_equal(false, form.resource_attribute_has_errors?(:items, 1, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 0, :id))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 1, :name))
 
-      assert_equal(false, form.resource_attribute_has_errors?(:items, 1, :id))
-      assert_equal(true, form.resource_attribute_has_errors?(:items, 2, :name))
-      assert_equal(true, form.resource_attribute_has_errors?(:items, 2, :id))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 1, :id))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :name))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :id))
+    end
+  end
+
+  describe "#with_each_resource(:items) do |item, index|" do
+    it "validations within the block are scoped to the resource" do
+      form = form_class.new(
+        items: [
+          {
+            name: "Sean",
+            id: 123,
+          },
+          {
+            name: "Leigh",
+            id: 456,
+          },
+          {
+            name: "",
+            id: 789,
+          },
+        ],
+      )
+      offset = 3
+      form.with_each_resource(:items, offset: offset) do |item, index|
+        form.validate_presence(:name)
+        form.append_error(:id, :is_invalid) if item["id"] > 500
+      end
+      assert_equal(false, form.resource_has_errors?(:items, offset + 0))
+      assert_equal(false, form.resource_has_errors?(:items, offset + 1))
+      assert_equal(true, form.resource_has_errors?(:items, offset + 2))
+
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 0, :id))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 1, :name))
+
+      assert_equal(false, form.resource_attribute_has_errors?(:items, offset + 1, :id))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :name))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :id))
     end
   end
 end

--- a/spec/extensions/resources_spec.rb
+++ b/spec/extensions/resources_spec.rb
@@ -1,0 +1,91 @@
+require_relative "../spec_helper"
+
+describe Gourami::Extensions::Resources do
+  let(:form_class) do
+    Class.new(Gourami::Form).tap do |form|
+      form.send(:include, Gourami::Extensions::Resources)
+      form.attribute(
+        :items,
+        description: "List of objects",
+        type: :array,
+        # element_type does not have to be so precisely defined, but it can be:
+        element_type: {
+          type: :hash,
+          key_type: :string,
+          value_type: lambda do |key, value|
+            case key
+            when *%w[id]
+              :integer
+            when *%w[name email]
+              :string
+            when *%w[is_archived]
+              :boolean
+            when *%w[amount]
+              :float
+            when *%w[created_at]
+              :time
+            else
+              raise "Unknown key: #{key.inspect}. (value: #{value.inspect})"
+            end
+          end,
+        },
+      )
+    end
+  end
+
+  describe "#append_resource_error and #resource_errors" do
+    it "#append_resource_error adds errors to the resource and #resource_errors returns them" do
+      form = form_class.new
+
+      assert_equal(false, form.any_resource_errors?)
+      assert_equal(false, form.any_errors?)
+
+      assert_equal(false, form.resource_has_errors?(:items, 0))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :id))
+
+      form.append_resource_error(:items, 0, :name, :is_invalid)
+
+      assert_equal(true, form.any_resource_errors?)
+      assert_equal(true, form.any_errors?)
+
+      assert_equal(true, form.resource_has_errors?(:items, 0))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :id))
+    end
+  end
+
+  describe "#with_resource" do
+    it "validations within the block are scoped to the resource" do
+      form = form_class.new(
+        items: [
+          {
+            name: "Sean",
+            id: 123,
+          },
+          {
+            name: "Leigh",
+            id: 456,
+          },
+          {
+            name: "",
+            id: 789,
+          },
+        ],
+      )
+      form.items.each_with_index do |item, index|
+        form.with_resource(:items, index) do
+          form.validate_presence(:name)
+          # TODO: support `append_error` on resource.
+          # form.append_error(:name, :is_invalid)
+        end
+      end
+      assert_equal(false, form.resource_has_errors?(:items, 0))
+      assert_equal(false, form.resource_has_errors?(:items, 1))
+      assert_equal(true, form.resource_has_errors?(:items, 2))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 1, :name))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, 2, :name))
+    end
+  end
+end

--- a/spec/extensions/resources_spec.rb
+++ b/spec/extensions/resources_spec.rb
@@ -76,16 +76,20 @@ describe Gourami::Extensions::Resources do
       form.items.each_with_index do |item, index|
         form.with_resource(:items, index) do
           form.validate_presence(:name)
-          # TODO: support `append_error` on resource.
-          # form.append_error(:name, :is_invalid)
+          form.append_error(:id, :is_invalid) if item["id"] > 500
         end
       end
       assert_equal(false, form.resource_has_errors?(:items, 0))
       assert_equal(false, form.resource_has_errors?(:items, 1))
       assert_equal(true, form.resource_has_errors?(:items, 2))
+
       assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :name))
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 0, :id))
       assert_equal(false, form.resource_attribute_has_errors?(:items, 1, :name))
+
+      assert_equal(false, form.resource_attribute_has_errors?(:items, 1, :id))
       assert_equal(true, form.resource_attribute_has_errors?(:items, 2, :name))
+      assert_equal(true, form.resource_attribute_has_errors?(:items, 2, :id))
     end
   end
 end


### PR DESCRIPTION
to support being able to use standard validations like `validate_presence`, etc, for form resources. Rather than having to manually perform validation logic and then `append_resource_error` manually.