### PR TITLE
support resource that is not a list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "uids"
+  ]
+}

--- a/lib/gourami/version.rb
+++ b/lib/gourami/version.rb
@@ -1,3 +1,3 @@
 module Gourami
-  VERSION = "2.0.0".freeze
+  VERSION = "2.1.0".freeze
 end

--- a/spec/extensions/resources_spec.rb
+++ b/spec/extensions/resources_spec.rb
@@ -135,7 +135,7 @@ describe Gourami::Extensions::Resources do
       assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :id))
 
       # Checking resource_attribute_has_errors? applies a default empty array to the errors hash.
-      # TODO: Should we try to update the library to avoid that that?
+      # TODO: Should we try to update the library to avoid that?
       assert_equal({
         items: {
           (offset + 2).to_s => {
@@ -238,7 +238,7 @@ describe Gourami::Extensions::Resources do
       assert_equal(true, form.resource_attribute_has_errors?(:items, offset + 2, :id))
 
       # Checking resource_attribute_has_errors? applies a default empty array to the errors hash.
-      # TODO: Should we try to update the library to avoid that that?
+      # TODO: Should we try to update the library to avoid that?
       assert_equal({
         items: {
           (offset + 2).to_s => {
@@ -299,7 +299,7 @@ describe Gourami::Extensions::Resources do
       assert_equal(true, form.resource_attribute_has_errors?(:items_hash, "ghi", :id))
 
       # Checking resource_attribute_has_errors? applies a default empty array to the errors hash.
-      # TODO: Should we try to update the library to avoid that that?
+      # TODO: Should we try to update the library to avoid that?
       assert_equal({
         items_hash: {
           "ghi" => {
@@ -400,7 +400,7 @@ describe Gourami::Extensions::Resources do
       assert_equal(true, form.resource_attribute_has_errors?(:items_hash, "ghi", :id))
 
       # Checking resource_attribute_has_errors? applies a default empty array to the errors hash.
-      # TODO: Should we try to update the library to avoid that that?
+      # TODO: Should we try to update the library to avoid that?
       assert_equal({
         items_hash: {
           "ghi" => {


### PR DESCRIPTION
Sometimes a resource is just a hash with properties, and not a list. This PR supports this.

Example:

```ruby
attribute(:branding_input, type: :hash, input_field: "InputObjects::SmartPageBrandingInput", required: true, skip: true)

def validate
  with_resource(:branding_input) do
    validate_format(:primary_color, /\A#(?:[0-9a-fA-F]{3}){1,2}\z/)
    validate_format(:background_overlay, /\Argba\((\s*(1?[0-9]{1,2}|2[0-4][0-9]|25[0-5])\s*,){3}\s*(0|0?\.\d+|1)\s*\)\z/)
  end
end
```